### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/contoso-traders-provisioning-deployment.yml
+++ b/.github/workflows/contoso-traders-provisioning-deployment.yml
@@ -3,6 +3,10 @@ name: contoso-traders-provisioning-deployment
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+  id-token: write
+
 env:
   ACR_NAME: contosotradersacr
   AKS_CLUSTER_NAME: contoso-traders-aks


### PR DESCRIPTION
Potential fix for [https://github.com/github-cloudlabsuser-1264/NP_Hack_6thJune/security/code-scanning/2](https://github.com/github-cloudlabsuser-1264/NP_Hack_6thJune/security/code-scanning/2)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimal permissions required for the workflow to function correctly. Since the workflow involves actions like checking out code, logging into Azure, and deploying resources, the `contents: read` permission is sufficient for accessing repository contents, and additional permissions can be added as needed for specific tasks (e.g., `id-token: write` for Azure login).

The `permissions` block can be added at the root level of the workflow to apply to all jobs or within the `provision` job to limit permissions specifically for that job.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
