### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/contoso-traders-app-deployment.yml
+++ b/.github/workflows/contoso-traders-app-deployment.yml
@@ -3,6 +3,9 @@ name: contoso-traders-app-deployment
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 env:
   ACR_NAME: contosotradersacr
   AKS_CLUSTER_NAME: contoso-traders-aks


### PR DESCRIPTION
Potential fix for [https://github.com/github-cloudlabsuser-1264/NP_Hack_6thJune/security/code-scanning/1](https://github.com/github-cloudlabsuser-1264/NP_Hack_6thJune/security/code-scanning/1)

To fix the issue, add a `permissions` block at the root level of the workflow file. This block will explicitly define the permissions for the `GITHUB_TOKEN`, limiting them to the least privileges required for the workflow. Based on the recommendation, the minimal permissions should be set to `contents: read`. If additional permissions are required for specific operations, they can be added as needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
